### PR TITLE
Python3

### DIFF
--- a/todotxt/indicator.py
+++ b/todotxt/indicator.py
@@ -24,7 +24,7 @@ from gi.repository import AppIndicator3 as appindicator, \
                           GObject, \
                           Gtk
 
-from list import TodoTxtList
+from todotxt.list import TodoTxtList
 
 
 IMG_PATH = os.path.dirname(os.path.realpath(__file__)) + '/img/'

--- a/todotxt/item.py
+++ b/todotxt/item.py
@@ -83,11 +83,12 @@ class TodoTxtItem(object):
         if not self.has_priority() and other.has_priority():
             return False
 
-        # Now we know both have priority, so sort by that next:
-        if self.priority < other.priority:
-            return True
-        if self.priority > other.priority:
-            return False
+        if self.has_priority() and other.has_priority():
+            # Now we know both have priority, so sort by that next:
+            if self.priority < other.priority:
+                return True
+            if self.priority > other.priority:
+                return False
 
         # Priorities are equal, so sort by actual text:
         if self.text < other.text:

--- a/todotxt/list.py
+++ b/todotxt/list.py
@@ -20,7 +20,7 @@
 import os
 import sys
 
-from item import TodoTxtItem
+from todotxt.item import TodoTxtItem
 
 
 class TodoTxtList(object):
@@ -47,10 +47,11 @@ class TodoTxtList(object):
         self.todo_filename = os.path.abspath(file_name)  # absolute path!
 
         try:
-            with open(self.todo_filename, 'a+') as f:
-                todo_lines = f.read()
+            f=open(self.todo_filename, "r+")
+            todo_lines = f.read()
+            f.close()
         except IOError:
-            print "Error opening file:\n" + self.todo_filename
+            print ("Error opening file:\n" + self.todo_filename)
             sys.exit(1)
 
         self.init_from_text(todo_lines)
@@ -107,7 +108,7 @@ class TodoTxtList(object):
             with open(self.todo_filename, 'w') as f:
                 f.write(str(self))
         except IOError:
-            print "Error writing to file:\n" + self.todo_filename
+            print ("Error writing to file:\n" + self.todo_filename)
             sys.exit(1)
 
     def __str__(self):

--- a/todotxt/list.py
+++ b/todotxt/list.py
@@ -47,9 +47,8 @@ class TodoTxtList(object):
         self.todo_filename = os.path.abspath(file_name)  # absolute path!
 
         try:
-            f=open(self.todo_filename, "r+")
-            todo_lines = f.read()
-            f.close()
+            with open(self.todo_filename, 'r+') as f:
+                todo_lines = f.read()
         except IOError:
             print ("Error opening file:\n" + self.todo_filename)
             sys.exit(1)


### PR DESCRIPTION
These are mostly minor syntax changes in order to be able to use python 3.8.2 with Ubuntu 20.04/Mint 20.

Opening the file with mode "a+" results in an empty todo list. Mode "r+" is absolutely required.
The additional comparison in item.py is required to make sure that .priority is really defined for both sides of the comparison. It would fail otherwise in case both items have no priority defined.

I am more a C guy, I don't know much about python. I didn't check if any of these changes break compatibility with older python versions like 2.7.
